### PR TITLE
Adding link to official product documentation on Learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The Microsoft Docs MCP Server supports quick installation across multiple develo
 | Connection errors | Verify your network connection and that the server URL is correctly entered |
 | No results returned | Try rephrasing your query with more specific technical terms |
 | Tool not appearing in VS Code | Restart VS Code or check that the MCP extension is properly installed |
+| HTTP status 405  | Method not allowed happens when a browser tries to connect to the endpoint. Try using the Docs MCP Server through VS Code GitHub Copilot or [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) instead. |
 
 ### 🆘 Getting Support
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The Microsoft Learn Docs MCP Server team is working on several enhancements:
 
 ## 📚 Additional Resources
 
+- [Microsoft Learn Docs MCP Server product documentation](http://learn.microsoft.com/training/support/mcp)
 - [Microsoft MCP Servers](https://github.com/microsoft/mcp)
 - [Microsoft Learn](https://learn.microsoft.com)
 - [Model Context Protocol Specification](https://modelcontextprotocol.io)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The Microsoft Learn Docs MCP Server team is working on several enhancements:
 
 ## 📚 Additional Resources
 
-- [Microsoft Learn Docs MCP Server product documentation](http://learn.microsoft.com/training/support/mcp)
+- [Microsoft Learn Docs MCP Server product documentation](https://learn.microsoft.com/training/support/mcp)
 - [Microsoft MCP Servers](https://github.com/microsoft/mcp)
 - [Microsoft Learn](https://learn.microsoft.com)
 - [Model Context Protocol Specification](https://modelcontextprotocol.io)


### PR DESCRIPTION
A few days ago, we published official product documentation on Learn. This change adds a link on the readme to those docs.