### PR TITLE
fix: query should be question

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ https://learn.microsoft.com/api/mcp
 
 | Tool Name | Description | Input Parameters |
 |-----------|-------------|------------------|
-| `microsoft_docs_search` | Performs semantic search against Microsoft official technical documentation | `query` (string): The search query for retrieval |
+| `microsoft_docs_search` | Performs semantic search against Microsoft official technical documentation | `question` (string): The search question for retrieval |
 
 ## 🔌 Installation & Getting Started
 


### PR DESCRIPTION
Clarify parameter naming and description for microsoft_docs_search tool to improve user experience.
> Parameter name: Changed from query to question
> Parameter description: Updated from "The search query for retrieval" to "The search question for retrieval"