### PR TITLE
fix: update command to use mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ https://learn.microsoft.com/api/mcp
 **Example JSON configuration:**
 ```json
 {
-  "microsoft.docs.mcp": {
-    "type": "http",
-    "url": "https://learn.microsoft.com/api/mcp"
-  }
+    "servers": {
+        "microsoft.docs.mcp": {
+            "type": "http",
+            "url": "https://learn.microsoft.com/api/mcp"
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
This pull request makes a small update to the example JSON configuration in the `README.md` file for the `https://learn.microsoft.com/api/mcp` endpoint. The change wraps the server configuration inside a `servers` object to better reflect the expected structure.
I believe this will help you test in your VSCode, create a file named mcp.json inside the .vscode directory