### PR TITLE
[WIP] Add MCP install instructions to skills

### DIFF
--- a/skills/microsoft-code-reference/SKILL.md
+++ b/skills/microsoft-code-reference/SKILL.md
@@ -7,6 +7,26 @@ compatibility: Requires Microsoft Learn MCP Server (https://learn.microsoft.com/
 
 # Microsoft Code Reference
 
+## Prerequisites: Connect to the Microsoft Learn MCP Server
+
+This skill requires the **Microsoft Learn MCP Server**. If it's not already connected, add it to your MCP client configuration:
+
+**Remote MCP Endpoint:** `https://learn.microsoft.com/api/mcp`
+
+**Sample config (works in most MCP clients):**
+```json
+{
+  "mcpServers": {
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    }
+  }
+}
+```
+
+No API key or authentication required. For client-specific setup (VS Code, Claude, Cursor, etc.), see the [full installation guide](https://github.com/MicrosoftDocs/mcp#-installation--getting-started).
+
 ## Tools
 
 | Need | Tool | Example |

--- a/skills/microsoft-docs/SKILL.md
+++ b/skills/microsoft-docs/SKILL.md
@@ -7,6 +7,26 @@ compatibility: Requires Microsoft Learn MCP Server (https://learn.microsoft.com/
 
 # Microsoft Docs
 
+## Prerequisites: Connect to the Microsoft Learn MCP Server
+
+This skill requires the **Microsoft Learn MCP Server**. If it's not already connected, add it to your MCP client configuration:
+
+**Remote MCP Endpoint:** `https://learn.microsoft.com/api/mcp`
+
+**Sample config (works in most MCP clients):**
+```json
+{
+  "mcpServers": {
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    }
+  }
+}
+```
+
+No API key or authentication required. For client-specific setup (VS Code, Claude, Cursor, etc.), see the [full installation guide](https://github.com/MicrosoftDocs/mcp#-installation--getting-started).
+
 ## Tools
 
 | Tool | Use For |

--- a/skills/microsoft-skill-creator/SKILL.md
+++ b/skills/microsoft-skill-creator/SKILL.md
@@ -9,6 +9,26 @@ compatibility: Requires Microsoft Learn MCP Server (https://learn.microsoft.com/
 
 Create hybrid skills for Microsoft technologies that store essential knowledge locally while enabling dynamic Learn MCP lookups for deeper details.
 
+## Prerequisites: Connect to the Microsoft Learn MCP Server
+
+This skill requires the **Microsoft Learn MCP Server**. If it's not already connected, add it to your MCP client configuration:
+
+**Remote MCP Endpoint:** `https://learn.microsoft.com/api/mcp`
+
+**Sample config (works in most MCP clients):**
+```json
+{
+  "mcpServers": {
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    }
+  }
+}
+```
+
+No API key or authentication required. For client-specific setup (VS Code, Claude, Cursor, etc.), see the [full installation guide](https://github.com/MicrosoftDocs/mcp#-installation--getting-started).
+
 ## About Skills
 
 Skills are modular packages that extend agent capabilities with specialized knowledge and workflows. A skill transforms a general-purpose agent into a specialized one for a specific domain.


### PR DESCRIPTION
If user only installed our skills but not our MCP, their agent needs to know how to install our MCP.