### PR TITLE
fix(cli): resolve symlinks for npm-link support and improve CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ https://learn.microsoft.com/api/mcp?maxTokenBudget=2000
 | `microsoft_docs_fetch` | Fetch and convert a Microsoft documentation page into markdown format | `url` (string): URL of the documentation page to read |
 | `microsoft_code_sample_search` | Search for official Microsoft/Azure code snippets and examples | `query` (string): Search query for Microsoft/Azure code snippets<br/>`language` (string, optional): Programming language filter.|
 
+## 💻 Companion CLI
+
+This repository also includes an in-repo companion CLI. See [`cli/README.md`](cli/README.md) for installation, usage, and full command reference.
+
 ## 🤖 Agent Skills
 
 [Agent Skills](https://agentskills.io/) are portable instruction packages that help AI agents use tools more effectively. We provide three skills that guide agents on when and how to use the Microsoft Learn MCP tools:

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Microsoft Learn Companion CLI
 
-`mslearn` is a thin companion CLI for the public Microsoft Learn MCP server. 
+`mslearn` is a thin companion CLI for the public Microsoft Learn MCP server.
 
 It gives you terminal-friendly commands for docs search, docs fetch, code sample search, and environment diagnostics.
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -106,13 +106,19 @@ function isZeroExitError(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'exitCode' in error && (error as { exitCode?: unknown }).exitCode === 0;
 }
 
-const resolvedArgv = (() => {
+export function resolveMainModuleUrl(argv1: string | undefined = process.argv[1]): string {
   try {
-    return pathToFileURL(realpathSync(process.argv[1] ?? '')).href;
+    return pathToFileURL(realpathSync(argv1 ?? '')).href;
   } catch {
-    return pathToFileURL(process.argv[1] ?? '').href;
+    try {
+      return pathToFileURL(argv1 ?? '').href;
+    } catch {
+      return '';
+    }
   }
-})();
+}
+
+const resolvedArgv = resolveMainModuleUrl();
 
 if (import.meta.url === resolvedArgv) {
   const exitCode = await runCli();


### PR DESCRIPTION
The CLI entry-point check (`import.meta.url === ...`) failed when invoked through an `npm link` symlink. Use `realpathSync` to resolve the actual file path before comparing.

Also restructures CLI documentation:
- Move quick-start snippet out of the root README into cli/README.md
- Add requirements, multiple install options (node, npx, npm link), full command reference, and endpoint configuration docs