### PR TITLE
Update Claude Code install to official plugin store

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-docs",
   "description": "Access official Microsoft documentation, API references, and code samples for Azure, .NET, Windows, and more.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Microsoft"
   },

--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ See [`cli/README.md`](cli/README.md) for the full command reference.
 
 ### Quick Setup
 
-These agent skills are packed in a `microsoft-docs` plugin together with the Learn MCP server itself. If you use Claude Code, run the following commands and restart Claude Code:
+These agent skills are packed in a `microsoft-docs` plugin together with the Learn MCP server itself. If you use Claude Code, run the following command and restart Claude Code:
 ```
-/plugin marketplace add microsoftdocs/mcp
-/plugin install microsoft-docs@microsoft-docs-marketplace
+/plugin install microsoft-docs@claude-plugins-official
 ```
 
 Or if you use GitHub Copilot CLI, run this command:
@@ -165,7 +164,7 @@ The Microsoft Learn MCP Server supports quick installation across multiple devel
 | **VS Code** | [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=microsoft-learn&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Flearn.microsoft.com%2Fapi%2Fmcp%22%7D) <br/> or search "@mcp learn" in Extensions to show "Microsoft Learn" MCP | [VS Code MCP Official Guide](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) |
 | **GitHub Copilot CLI** | `/plugin install microsoftdocs/mcp` | |
 | **Claude Desktop** | Follow "Add custom connector" instructions in official guide. | [Claude Desktop Remote MCP Guide](https://modelcontextprotocol.io/docs/develop/connect-remote-servers) |
-| **Claude Code** | Install via plugin marketplace (includes MCP server + skills) - see [Quick Setup](#-agent-skills) | [Claude Code Remote MCP Guide](https://code.claude.com/docs/en/mcp) |
+| **Claude Code** | `/plugin install microsoft-docs@claude-plugins-official` (includes MCP server + skills) | [Claude Code Remote MCP Guide](https://code.claude.com/docs/en/mcp) |
 | **Visual Studio** | Upgrade to latest VS 2022 or 2026, "Microsoft Learn" MCP is already built-in | [Visual Studio MCP Official Guide](https://learn.microsoft.com/en-us/visualstudio/ide/mcp-servers?view=vs-2022) |
 | **Cursor IDE** | [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=microsoft-learn&config=eyJuYW1lIjoibWljcm9zb2Z0LWxlYXJuIiwidHlwZSI6Imh0dHAiLCJ1cmwiOiJodHRwczovL2xlYXJuLm1pY3Jvc29mdC5jb20vYXBpL21jcCJ9) | [Cursor MCP Official Guide](https://docs.cursor.com/context/model-context-protocol) |
 | **Codex** | `codex mcp add "microsoft-learn" --url "https://learn.microsoft.com/api/mcp"`| [Codex MCP documentation](https://github.com/openai/codex/blob/main/codex-rs/config.md#mcp_servers) |


### PR DESCRIPTION
## Summary
- Updated Claude Code install instructions to use the official plugin store: `/plugin install microsoft-docs@claude-plugins-official` (replaces the two-step marketplace workflow)
- Bumped plugin version to 0.3.1

## Test plan
- [ ] Verify `/plugin install microsoft-docs@claude-plugins-official` works in Claude Code
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)